### PR TITLE
Double square brackets for style.

### DIFF
--- a/glesys
+++ b/glesys
@@ -78,10 +78,10 @@ EOF
             template="${__dir}/templates/$url"
         fi
 
-        if [ -f $options ]; then
+        if [[ -f $options ]]; then
             source "$options"
         fi
-        if [ -f $template ]; then
+        if [[ -f $template ]]; then
             api_post_data="$(source "$template")"
         fi
     fi


### PR DESCRIPTION
All other instances uses double square brackets and we are indeed in bash mode, no reason to not use them.