### PR TITLE
REFACTOR: Indentation style guide says 2 spaces not 4.

### DIFF
--- a/glesys
+++ b/glesys
@@ -10,21 +10,21 @@ set -o pipefail # exit when a pipe fails
 main()
 {(
 
-    __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    __file="${__dir}/$(basename "${BASH_SOURCE[0]}")"
-    __base="$(basename ${__file} .sh)"
-    __root="$(cd "$(dirname "${__dir}")" && pwd)"
+  __dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  __file="${__dir}/$(basename "${BASH_SOURCE[0]}")"
+  __base="$(basename ${__file} .sh)"
+  __root="$(cd "$(dirname "${__dir}")" && pwd)"
 
-    show_error()
-    {(
-        error="${1:-'An unknown error occurred.'}"
-        >&2 echo "${__file} >> ERROR: $error"
-        exit 1
-    )}
+  show_error()
+  {(
+    error="${1:-'An unknown error occurred.'}"
+    >&2 echo "${__file} >> ERROR: $error"
+    exit 1
+  )}
 
-    show_help()
-    {
-        cat <<EOF
+  show_help()
+  {
+    cat <<EOF
                    ----------------------
                      Glesys Bash Client
                    ----------------------
@@ -40,11 +40,11 @@ link:    https://github.com/GleSYS/API/wiki/API-Documentation
 usage:   ./glesys <show|send|help> <url> <options> <template>
 example: ./glesys send server/create ./options/server/create ./templates/server/create
 EOF
-    }
+  }
 
-    show_url_help()
-    {
-        cat <<EOF
+  show_url_help()
+  {
+    cat <<EOF
                    ----------------------
                      Glesys Bash Client
                    ----------------------
@@ -52,78 +52,78 @@ link:    https://github.com/GleSYS/API/wiki/API-Documentation#${url/\//}
 usage:   ./glesys <show|send|help> <url> <options> <template>
 example: ./glesys $action $url $options $template
 EOF
-    }
+  }
 
-    action="${1}"
-    url="${2}"
-    options="${3}"
-    template="${4}"
-    are_you_sure="${5}"
-    api_post_data='{}'
+  action="${1}"
+  url="${2}"
+  options="${3}"
+  template="${4}"
+  are_you_sure="${5}"
+  api_post_data='{}'
 
-    # overridden by any variables set in options
-    # good for SSH key, etc.
-    source "${__dir}/config"
+  # overridden by any variables set in options
+  # good for SSH key, etc.
+  source "${__dir}/config"
 
-    if [[ $action != "help" && ! $url ]]; then
-        show_error 'Second parameter is required.'
+  if [[ $action != "help" && ! $url ]]; then
+      show_error 'Second parameter is required.'
+  fi
+  if [[ $url ]]; then
+    if [[ ! $options ]]; then
+        echo 'Guessing options path.'
+        options="${__dir}/options/$url"
     fi
-    if [[ $url ]]; then
-        if [[ ! $options ]]; then
-            echo 'Guessing options path.'
-            options="${__dir}/options/$url"
-        fi
-        if [[ ! $template ]]; then
-            echo 'Guessing template path.'
-            template="${__dir}/templates/$url"
-        fi
-
-        if [ -f $options ]; then
-            source "$options"
-        fi
-        if [ -f $template ]; then
-            api_post_data="$(source "$template")"
-        fi
+    if [[ ! $template ]]; then
+        echo 'Guessing template path.'
+        template="${__dir}/templates/$url"
     fi
 
-    case $action in
-        "show")
-            echo
-            echo 'To send this request run:'
-            echo "${__file} send $url $options $template"
-            echo
-            echo 'REQUEST:'
-            echo "curl -X POST -H \"$api_content_type\" -k --basic -u $api_auth -d \"$api_post_data\" $api_base_url$url"
-            ;;
-        "send")
-            if [[ $are_you_sure == "Y" ]]; then
-                reply=$are_you_sure
-            else
-                read -p 'Are you sure? [Y/n]: ' -n2 -r -t10 reply
-            fi
+    if [ -f $options ]; then
+        source "$options"
+    fi
+    if [ -f $template ]; then
+        api_post_data="$(source "$template")"
+    fi
+  fi
 
-            if [[ $reply == "Y" ]]; then
-                curl -X POST \
-                    -H "$api_content_type" \
-                    -k --basic \
-                    -u $api_auth \
-                    -d "$api_post_data" \
-                    $api_base_url$url
-                echo
-            else
-                echo 'Request aborted.'
-            fi
-            ;;
-        "help")
-            if [[ ! $url ]]; then
-                show_help
-            else
-                show_url_help $action $url
-            fi
-            ;;
-        *)
-            show_error 'Invalid action.'
-    esac
+  case $action in
+    "show")
+      echo
+      echo 'To send this request run:'
+      echo "${__file} send $url $options $template"
+      echo
+      echo 'REQUEST:'
+      echo "curl -X POST -H \"$api_content_type\" -k --basic -u $api_auth -d \"$api_post_data\" $api_base_url$url"
+      ;;
+    "send")
+      if [[ $are_you_sure == "Y" ]]; then
+          reply=$are_you_sure
+      else
+          read -p 'Are you sure? [Y/n]: ' -n2 -r -t10 reply
+      fi
+
+      if [[ $reply == "Y" ]]; then
+          curl -X POST \
+              -H "$api_content_type" \
+              -k --basic \
+              -u $api_auth \
+              -d "$api_post_data" \
+              $api_base_url$url
+          echo
+      else
+          echo 'Request aborted.'
+      fi
+      ;;
+    "help")
+      if [[ ! $url ]]; then
+          show_help
+      else
+          show_url_help $action $url
+      fi
+      ;;
+    *)
+      show_error 'Invalid action.'
+  esac
 )}
 
 main "${1:-help}" "${2:-}" "${3:-}" "${4:-}" "${5:-no}"


### PR DESCRIPTION
Style guide linked in README states: [Indent 2 spaces. No tabs.](https://google.github.io/styleguide/shell.xml#Indentation)
With the longer text leaving some interpretation space. 
```
  Use blank lines between blocks to improve readability. Indentation
  is two spaces. Whatever you do, don't use tabs. For existing files,
  stay faithful to the existing indentation.
```